### PR TITLE
bower install does not work

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,8 @@
+{
+    "directory": "./bower_components",
+    "registry": {
+        "search": [
+            "https://registry.bower.io"
+        ]
+    }
+}


### PR DESCRIPTION
Bower registry is under a new domain.
 `bower install` does not work, at least for me till I added `.bowerrc` and set the registry to `https://registry.bower.io`