### PR TITLE
Show item name and area rather than an empty slot in room editor

### DIFF
--- a/src/soma-app/room-editor.html
+++ b/src/soma-app/room-editor.html
@@ -122,7 +122,7 @@
                   items="[[availableItems]]"
                   item-label-path="name"
                   item-value-path="value"
-                  value="[[item.id]]"
+                  value="[[item]]"
                   on-change="_itemValueUpdated"
                 >
                   <template>


### PR DESCRIPTION
Resolves #13.

See screenshot.
<img width="1657" alt="screen shot 2018-10-07 at 2 32 58 pm" src="https://user-images.githubusercontent.com/8154105/46585359-eba3da80-ca3d-11e8-8ae8-1ca087a39217.png">
