### PR TITLE
Add background to legend

### DIFF
--- a/src/soma-app/area-map.html
+++ b/src/soma-app/area-map.html
@@ -33,6 +33,7 @@
     }
     td:hover {
       background-color: var(--ranvier-light-green);
+      z-index: 999;
       top: -1px;
     }
     tr:first-child td:first-child { border-top-left-radius: 8px; }
@@ -73,9 +74,13 @@
       background-color: #0ef;
     }
     .legend {
+      z-index: 998;
+      background-color: rgb(192, 192, 192);
+      border-radius: 2px;
       position: absolute;
       top: 12px;
       left: 12px;
+      padding: 2px;
       display: flex;
       flex-direction: column;
     }
@@ -90,7 +95,6 @@
     }
     .legend-has-items {
       background-color: #0ef;
-      display: inline-block;
     }
     </style>
 


### PR DESCRIPTION
This seeks to address #12. Maybe not ideal but it adds a background to the legend, and if it does cover a room, hovering over the room will pop it in front of the legend.